### PR TITLE
feat: add region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add @boilingdata/node-boilingdata
 import { BoilingData, isDataResponse } from "@boilingdata/node-boilingdata";
 
 async function main() {
-  const bdInstance = new BoilingData({ username: process.env["BD_USERNAME"], password: process.env["BD_PASSWORD"] });
+  const bdInstance = new BoilingData({ region: "eu-west-1", username: process.env["BD_USERNAME"], password: process.env["BD_PASSWORD"] });
   await bdInstance.connect();
   const rows = await new Promise<any[]>((resolve, reject) => {
     let r: any[] = [];
@@ -37,6 +37,9 @@ async function main() {
 ```
 
 This repository contains JS/TS BoilingData SDK. Please see the integration tests on `tests/query.test.ts` for for more examples.
+
+### Region
+BoilingData is globally distributed and can work with S3 data in any region. The region specified when creating the `BoilingData` instance dictates where data processing occurs - this should be the same as the region where your data is housed to ensure there is low latency and you are not charged unnecessary data egress fees by Amazon. If you need to query datasets in buckets across multiple regions, you should create multiple `BoilingData` instances.
 
 ### Callbacks
 
@@ -62,6 +65,7 @@ Global callbacks can be set when creating the BoilingData instance.
 
 ```typescript
 new BoilingData({
+  region: "eu-west-1", 
   username,
   password,
   globalCallbacks: {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "onchange": "^7.0.2",
-    "prettier": "^2.0.5",
+    "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.4",
     "typescript": "^4.1.3"

--- a/src/boilingdata/boilingdata.ts
+++ b/src/boilingdata/boilingdata.ts
@@ -22,6 +22,7 @@ export interface IBDCallbacks {
 export interface IBoilingData {
   username: string;
   password: string;
+  region: string;
   logLevel?: "trace" | "debug" | "info" | "warn" | "error" | "fatal"; // Match with Bunyan
   globalCallbacks?: IBDCallbacks;
 }
@@ -103,7 +104,8 @@ export class BoilingData {
     return new Promise((resolve, reject) => {
       const sock = this.socketInstance;
       const cbs = this.props.globalCallbacks;
-      getBoilingDataCredentials(this.props.username, this.props.password).then(creds => {
+      const region = this.props.region ?? "eu-west-1";
+      getBoilingDataCredentials(this.props.username, this.props.password, region).then(creds => {
         this.creds = creds;
         this.logger.debug(this.creds);
         sock.socket = new WebSocket(this.creds.signedWebsocketUrl);

--- a/src/boilingdata/boilingdata.ts
+++ b/src/boilingdata/boilingdata.ts
@@ -22,7 +22,7 @@ export interface IBDCallbacks {
 export interface IBoilingData {
   username: string;
   password: string;
-  region: string;
+  region?: string;
   logLevel?: "trace" | "debug" | "info" | "warn" | "error" | "fatal"; // Match with Bunyan
   globalCallbacks?: IBDCallbacks;
 }

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -49,7 +49,7 @@ export async function getBoilingDataCredentials(
   const credentials = { accessKeyId, secretAccessKey, sessionToken };
   const path = "/dev";
   const protocol = "wss";
-  const webSocketHost = `${region}.api.boilingdata.com`
+  const webSocketHost = `${region}.api.boilingdata.com`;
   const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, protocol, path, region);
   const cognitoUsername = idToken.decodePayload()["cognito:username"];
   return { cognitoUsername, signedWebsocketUrl };

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -6,7 +6,6 @@ import { getSignedWssUrl } from "./signature";
 const region = "eu-west-1";
 const UserPoolId = "eu-west-1_0GLV9KO1p";
 const IdentityPoolId = "eu-west-1:bce21571-e3a6-47a4-8032-fd015213405f";
-const webSocketHost = "m9fhs4t5vh.execute-api.eu-west-1.amazonaws.com";
 const Logins = `cognito-idp.${region}.amazonaws.com/${UserPoolId}`;
 const poolData = { UserPoolId, ClientId: "6timr8knllr4frovfvq8r2o6oo" };
 const Pool = new CognitoUserPool(poolData);
@@ -50,6 +49,7 @@ export async function getBoilingDataCredentials(
   const credentials = { accessKeyId, secretAccessKey, sessionToken };
   const path = "/dev";
   const protocol = "wss";
+  const webSocketHost = `${region}.api.boilingdata.com`
   const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, protocol, path, region);
   const cognitoUsername = idToken.decodePayload()["cognito:username"];
   return { cognitoUsername, signedWebsocketUrl };

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -36,7 +36,7 @@ async function refreshCredsWithToken(idToken: string): Promise<CognitoIdentityCr
   return creds;
 }
 
-export async function getBoilingDataCredentials(username: string, password: string): Promise<BDCredentials> {
+export async function getBoilingDataCredentials(username: string, password: string, region: string): Promise<BDCredentials> {
   const idToken = await getIdToken(username, password);
   const creds = await refreshCredsWithToken(idToken.getJwtToken());
   const accessKeyId = creds.data?.Credentials?.AccessKeyId;
@@ -44,7 +44,7 @@ export async function getBoilingDataCredentials(username: string, password: stri
   const sessionToken = creds.data?.Credentials?.SessionToken;
   if (!accessKeyId || !secretAccessKey) throw new Error("Missing credentials (after refresh)!");
   const credentials = { accessKeyId, secretAccessKey, sessionToken };
-  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials);
+  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, "/dev", region);
   const cognitoUsername = idToken.decodePayload()["cognito:username"];
   return { cognitoUsername, signedWebsocketUrl };
 }

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -49,7 +49,8 @@ export async function getBoilingDataCredentials(
   if (!accessKeyId || !secretAccessKey) throw new Error("Missing credentials (after refresh)!");
   const credentials = { accessKeyId, secretAccessKey, sessionToken };
   const path = "/dev";
-  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, path, region);
+  const protocol = "wss";
+  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, protocol, path, region);
   const cognitoUsername = idToken.decodePayload()["cognito:username"];
   return { cognitoUsername, signedWebsocketUrl };
 }

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -36,7 +36,11 @@ async function refreshCredsWithToken(idToken: string): Promise<CognitoIdentityCr
   return creds;
 }
 
-export async function getBoilingDataCredentials(username: string, password: string, region: string): Promise<BDCredentials> {
+export async function getBoilingDataCredentials(
+  username: string,
+  password: string,
+  region: string,
+): Promise<BDCredentials> {
   const idToken = await getIdToken(username, password);
   const creds = await refreshCredsWithToken(idToken.getJwtToken());
   const accessKeyId = creds.data?.Credentials?.AccessKeyId;
@@ -44,7 +48,8 @@ export async function getBoilingDataCredentials(username: string, password: stri
   const sessionToken = creds.data?.Credentials?.SessionToken;
   if (!accessKeyId || !secretAccessKey) throw new Error("Missing credentials (after refresh)!");
   const credentials = { accessKeyId, secretAccessKey, sessionToken };
-  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, "/dev", region);
+  const path = "/dev";
+  const signedWebsocketUrl = await getSignedWssUrl(webSocketHost, credentials, path, region);
   const cognitoUsername = idToken.decodePayload()["cognito:username"];
   return { cognitoUsername, signedWebsocketUrl };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,9 +2919,9 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.5:
+prettier@^2.6.2:
   version "2.6.2"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 pretty-format@^27.0.0, pretty-format@^27.5.1:


### PR DESCRIPTION
This allows passing of a custom region string down to the `getSignedWssUrl` function. 

The cognito functions are still hardcoded to eu-west-1.